### PR TITLE
Encapsulate ResponseContext lifecycle of WorkflowTasks to the task.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.ebay.taskgraph</groupId>
     <artifactId>TaskGraph</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
     <name>Task Graph Toolkit</name>
     <description>An extension of basic Java concurrency patterns to build a set of interdependent tasks.</description>

--- a/src/main/java/com/ebay/taskgraph/diagnostic/ProfilerValidator.java
+++ b/src/main/java/com/ebay/taskgraph/diagnostic/ProfilerValidator.java
@@ -45,7 +45,7 @@ public class ProfilerValidator {
         String taskName = getTaskName(profiler);
         if (taskName != null) {
             if (entries.containsKey(taskName)) {
-                throw new RuntimeException("Duplicate task name: " + profiler.getName());
+                throw new RuntimeException("Duplicate task name: " + taskName);
             }
             entries.put(taskName, Boolean.TRUE);
         }

--- a/src/main/java/com/ebay/taskgraph/executor/workflow/WorkflowTask.java
+++ b/src/main/java/com/ebay/taskgraph/executor/workflow/WorkflowTask.java
@@ -21,6 +21,7 @@ package com.ebay.taskgraph.executor.workflow;
 import com.ebay.taskgraph.context.ResponseContext;
 import com.ebay.taskgraph.executor.CallableTaskConfig;
 import com.ebay.taskgraph.executor.ICallableTask;
+import com.ebay.taskgraph.executor.ICallableTaskFuture;
 import com.ebay.taskgraph.executor.Task;
 
 /**
@@ -31,20 +32,21 @@ public class WorkflowTask<T> extends Task implements ICallableTask<T> {
     private final IWorkflowFactory workflowFactory;
     private final IWorkflowExecutor<T> executor;
 
-    public WorkflowTask(CallableTaskConfig config, IWorkflowFactory workflowFactory, IWorkflowExecutor<T> task) {
-        this(task.getClass().getSimpleName(), config, workflowFactory, task);
+    public WorkflowTask(
+          CallableTaskConfig config,
+          IWorkflowFactory workflowFactory,
+          IWorkflowExecutor<T> executor,
+          ICallableTaskFuture<?> ... dependencies) {
+        this(executor.getClass().getSimpleName(), config, workflowFactory, executor, dependencies);
     }
 
-    public WorkflowTask(CallableTaskConfig config, ResponseContext rc, IWorkflowFactory workflowFactory, IWorkflowExecutor<T> executor) {
-        this(rc, config, workflowFactory, executor);
-    }
-
-    public WorkflowTask(String taskName, CallableTaskConfig config, IWorkflowFactory workflowFactory, IWorkflowExecutor<T> executor) {
-        this(new ResponseContext(config.diagnosticConfig, taskName), config, workflowFactory, executor);
-    }
-
-    public WorkflowTask(ResponseContext rc, CallableTaskConfig config, IWorkflowFactory workflowFactory, IWorkflowExecutor<T> executor) {
-        super(rc, config);
+    public WorkflowTask(
+          String taskName,
+          CallableTaskConfig config,
+          IWorkflowFactory workflowFactory,
+          IWorkflowExecutor<T> executor,
+          ICallableTaskFuture<?> ... dependencies) {
+        super(taskName, new ResponseContext(config.diagnosticConfig, executor.getClass().getSimpleName()), config, dependencies);
         this.workflowFactory = workflowFactory;
         this.executor = executor;
     }

--- a/src/test/java/com/ebay/taskgraph/util/JacksonJsonHelperTest.java
+++ b/src/test/java/com/ebay/taskgraph/util/JacksonJsonHelperTest.java
@@ -21,8 +21,6 @@ package com.ebay.taskgraph.util;
 import java.io.InputStream;
 import java.util.List;
 
-import org.junit.Test;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 
 public class JacksonJsonHelperTest implements IJsonHelper {


### PR DESCRIPTION
Clients can specify task names but generally the ResponseContext name should be the task or workflow executor name for aggregate task logging.